### PR TITLE
Headers improvement

### DIFF
--- a/lib/components/DemoLayout.tsx
+++ b/lib/components/DemoLayout.tsx
@@ -1,10 +1,11 @@
 import { AppsSidebar } from "./AppsSidebar";
 import { Header } from "./Header";
-import Toolname from "@/assets/toolname.svg";
+import Toolname from "@/assets/tool-name.svg";
+
 export const DemoLayout = () => {
   return (
     <div>
-      <Header endSlot={<div className="w-full"></div>} toolNameSrc={Toolname} />
+      <Header endSlot={<div className="text-gray-100 mr-2">End slot content</div>} toolNameSrc={Toolname} />
       <div className="flex h-full w-full items-center justify-center">
         <AppsSidebar activeLink="debugger" />
         <div className="w-full h-full"></div>

--- a/lib/components/Header/Header.stories.tsx
+++ b/lib/components/Header/Header.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Header } from "./index";
+import Toolname from "@/assets/tool-name.svg";
 
 const meta = {
   title: "Components/Header",
@@ -17,6 +18,8 @@ type Story = StoryObj<typeof Header>;
 
 export const DefaultHeader: Story = {
   args: {
-    endSlot: <span className="w-full">End Slot</span>,
+    endSlot: <div className="text-gray-100 mr-2">End slot content</div>,
+    ghRepoName: "graypaper-reader",
+    toolNameSrc: Toolname,
   },
 };

--- a/lib/components/Header/components/GithubDropdownMenu.tsx
+++ b/lib/components/Header/components/GithubDropdownMenu.tsx
@@ -1,10 +1,10 @@
+import { useIsSmallBreakpoint } from "@/hooks";
 import { Button } from "@/ui/button";
-import { DropdownMenu, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuContent } from "@/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdown-menu";
 import { ChevronDown, EllipsisVertical, ExternalLink } from "lucide-react";
-import { useEffect, useState } from "react";
 
 export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
-  const isSmall = useBreakpoint("(max-width: 640px)");
+  const isSmall = useIsSmallBreakpoint();
 
   return (
     <DropdownMenu>
@@ -68,15 +68,3 @@ export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
     </DropdownMenu>
   );
 };
-function useBreakpoint(query: string) {
-  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
-
-  useEffect(() => {
-    const media = window.matchMedia(query);
-    const listener = () => setMatches(media.matches);
-    media.addEventListener("change", listener);
-    return () => media.removeEventListener("change", listener);
-  }, [query]);
-
-  return matches;
-}

--- a/lib/components/Header/components/GithubDropdownMenu.tsx
+++ b/lib/components/Header/components/GithubDropdownMenu.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@/ui/button";
+import { DropdownMenu, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuContent } from "@/ui/dropdown-menu";
+import { ChevronDown, EllipsisVertical, ExternalLink } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
+  const isSmall = useBreakpoint("(max-width: 640px)");
+
+  return (
+    <DropdownMenu>
+      {!isSmall && (
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outlineBrand"
+            className="max-sm:hidden text-brand bg-transparent border-brand focus:bg-[#2D2D2D] hover:bg-[#2D2D2D] hover:text-brand focus-visible:shadow-none mr-4 px-3 h-[32px]"
+          >
+            Github&nbsp;
+            <ChevronDown height={20} />
+          </Button>
+        </DropdownMenuTrigger>
+      )}
+
+      {isSmall && (
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            className="sm:hidden text-brand bg-transparent border-brand focus:bg-[#2D2D2D] hover:bg-[#2D2D2D] hover:text-brand focus-visible:shadow-none mr-4 px-3 h-[32px] sm-hidden"
+          >
+            <EllipsisVertical />
+          </Button>
+        </DropdownMenuTrigger>
+      )}
+
+      <DropdownMenuContent className="bg-[#242424] mt-1 p-4 border-none text-white min-w-[315px]">
+        <DropdownMenuItem
+          onSelect={() => window.open(`https://github.com/FluffyLabs/${ghRepoName}/issues/new`, "_blank")}
+          className="pl-3 py-3 flex items-start justify-between hover:bg-[#2D2D2D] focus:bg-[#2D2D2D] focus:text-white"
+        >
+          <div className="flex flex-col">
+            <span className="text-sm font-medium mb-1">Report an issue or suggestion</span>
+            <span className="text-xs text-muted-foreground">Go to the issue creation page</span>
+          </div>
+          <ExternalLink className="text-brand-dark dark:text-brand" size={16} />
+        </DropdownMenuItem>
+
+        <DropdownMenuItem
+          onSelect={() => window.open(`https://github.com/FluffyLabs/${ghRepoName}`, "_blank")}
+          className="pl-3 py-3 flex items-start justify-between hover:bg-[#2D2D2D] focus:bg-[#2D2D2D] focus:text-whit"
+        >
+          <div className="flex flex-col">
+            <span className="text-sm font-medium mb-1">Star us on Github to show support</span>
+            <span className="text-xs text-muted-foreground">Visit our Github</span>
+          </div>
+          <ExternalLink className="text-brand-dark dark:text-brand" size={16} />
+        </DropdownMenuItem>
+
+        <DropdownMenuItem
+          onSelect={() => window.open(`https://github.com/FluffyLabs/${ghRepoName}/fork`, "_blank")}
+          className="pl-3 py-3 flex items-start justify-between hover:bg-[#2D2D2D] focus:bg-[#2D2D2D] focus:text-whit"
+        >
+          <div className="flex flex-col">
+            <span className="text-sm font-medium mb-1">Fork & contribute</span>
+            <span className="text-xs text-muted-foreground pt-1">Opens the fork creation page</span>
+          </div>
+          <ExternalLink className="text-brand-dark dark:text-brand" size={16} />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+function useBreakpoint(query: string) {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}

--- a/lib/components/Header/index.tsx
+++ b/lib/components/Header/index.tsx
@@ -43,19 +43,39 @@ export const Header = ({
 };
 
 const Environment = () => {
-  const { host } = window.location;
-  let env = "PR preview";
-  if (host === "pvm.fluffylabs.dev") {
-    env = "prod";
-  } else if (host === "pvm-debugger.netlify.app") {
-    env = "beta";
-  }
-
-  env = "beta";
+  const badgeName = getRightBadgeName();
 
   return (
     <Badge className="px-2 py-[0.5px] sm:py-1 bg-brand text-[10px] max-sm:text-[7px] text-black whitespace-nowrap hover:bg-brand">
-      {env}
+      {badgeName}
     </Badge>
   );
+};
+
+function getRightBadgeName() {
+  if (isSubdomainOfFullyLabs()) {
+    return undefined;
+  }
+  if (isPreviewSubdomain()) {
+    return "PR preview";
+  }
+  if (isSubdomainOfNetlifyApp()) {
+    return "beta";
+  }
+  return "dev";
+}
+
+const isSubdomainOfFullyLabs = () => {
+  const { host } = window.location;
+  return host.endsWith(".fluffylabs.dev");
+};
+
+const isSubdomainOfNetlifyApp = () => {
+  const { host } = window.location;
+  return host.endsWith(".netlify.app");
+};
+
+const isPreviewSubdomain = () => {
+  const { host } = window.location;
+  return host.endsWith(".netlify.app") && host.startsWith("deploy-preview");
 };

--- a/lib/components/Header/index.tsx
+++ b/lib/components/Header/index.tsx
@@ -3,83 +3,40 @@ import Brand from "@/assets/brand.svg";
 
 import { Separator } from "@radix-ui/react-separator";
 import { Badge } from "@/ui/badge";
-import { Button } from "@/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdown-menu";
-import { ChevronDown, ExternalLink } from "lucide-react";
-import type { JSX } from "react";
+import { type JSX } from "react";
+import { GithubDropdownMenu } from "./components/GithubDropdownMenu";
 
-export const Header = ({ endSlot, toolNameSrc }: { endSlot?: JSX.Element; toolNameSrc: string }) => {
+export const Header = ({
+  endSlot,
+  toolNameSrc,
+  ghRepoName = "pvm-debugger",
+  keepNameWhenSmall = false,
+}: {
+  endSlot?: JSX.Element;
+  toolNameSrc: string;
+  ghRepoName?: string;
+  keepNameWhenSmall?: boolean;
+}) => {
   return (
     <div className="bg-[#242424] w-full flex flex-row items-center justify-between py-[18px] text-xs overflow-hidden border-b border-b-secondary-foreground dark:border-b-brand">
       <div className="flex items-center gap-5 sm:w-full">
-        <a href="/" className="flex items-center pl-4">
+        <a href="/" className="flex items-center pl-4 shrink-0">
           <img src={Logo} alt="FluffyLabs logo" className="h-[40px] max-w-fit" />
-          <img src={Brand} alt="FluffyLabs brand" className="hidden md:inline ml-4 h-[28px]" />
+          <img src={Brand} alt="FluffyLabs brand" className="max-sm:hidden md:inline ml-4 h-[28px]" />
         </a>
-        <Separator className="bg-gray-600 w-[1px] h-[40px] sm:h-[50px]" orientation="vertical" />
-        <div className="flex max-sm:flex-col-reverse max-sm:hidden items-end md:items-center h-[50px]">
+        <Separator className="bg-gray-600 w-[1px] h-[40px] sm:h-[50px] " orientation="vertical" />
+        <div
+          className={`flex max-sm:flex-col-reverse ${!keepNameWhenSmall ? "max-sm:hidden" : ""} items-end md:items-center h-[50px]`}
+        >
           <img src={toolNameSrc} alt="FluffyLabs brand" className="h-[40px]" />
           <div className="shrink sm:ml-1 sm:mb-4">
             <Environment />
           </div>
         </div>
       </div>
-      <div className="flex w-full items-center max-sm:ml-2">
+      <div className="flex w-full items-center max-sm:ml-2 justify-end">
         {endSlot}
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outlineBrand"
-              className="max-sm:hidden text-brand bg-transparent border-brand focus:bg-[#2D2D2D] hover:bg-[#2D2D2D] hover:text-brand focus-visible:shadow-none  mr-4 px-3 h-[32px]"
-            >
-              <a
-                target="_blank"
-                href="https://github.com/fluffylabs/pvm-debugger"
-                rel="noreferrer"
-                className="flex items-center text-xs"
-              >
-                Github&nbsp;
-                <ChevronDown height={20} />
-              </a>
-            </Button>
-          </DropdownMenuTrigger>
-
-          <DropdownMenuContent className="bg-[#242424] mt-1 p-4 border-none text-white min-w-[315px]">
-            <DropdownMenuItem
-              onSelect={() => window.open("https://github.com/FluffyLabs/pvm-debugger/issues/new", "_blank")}
-              className="pl-3 py-3 flex items-start justify-between hover:bg-[#2D2D2D] focus:bg-[#2D2D2D] focus:text-white"
-            >
-              <div className="flex flex-col">
-                <span className="text-sm font-medium mb-1">Report an issue or suggestion</span>
-                <span className="text-xs text-muted-foreground">Go to the issue creation page</span>
-              </div>
-              <ExternalLink className="text-brand-dark dark:text-brand" size={16} />
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              onSelect={() => window.open("https://github.com/FluffyLabs/pvm-debugger", "_blank")}
-              className="pl-3 py-3 flex items-start justify-between hover:bg-[#2D2D2D] focus:bg-[#2D2D2D] focus:text-whit"
-            >
-              <div className="flex flex-col">
-                <span className="text-sm font-medium mb-1">Star us on Github to show support</span>
-                <span className="text-xs text-muted-foreground">Visit our Github</span>
-              </div>
-              <ExternalLink className="text-brand-dark dark:text-brand" size={16} />
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              onSelect={() => window.open("https://github.com/FluffyLabs/pvm-debugger/fork", "_blank")}
-              className="pl-3 py-3 flex items-start justify-between hover:bg-[#2D2D2D] focus:bg-[#2D2D2D] focus:text-whit"
-            >
-              <div className="flex flex-col">
-                <span className="text-sm font-medium mb-1">Fork & contribute</span>
-                <span className="text-xs text-muted-foreground pt-1">Opens the fork creation page</span>
-              </div>
-              <ExternalLink className="text-brand-dark dark:text-brand" size={16} />
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <GithubDropdownMenu ghRepoName={ghRepoName} />
       </div>
     </div>
   );

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export function useBreakpoint(query: string) {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}
+
+export function useIsSmallBreakpoint() {
+  return useBreakpoint("(max-width: 640px)");
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
 import "./global.css";
 
 export * from "./components";
+export * from "./hooks";
+export * from "./utils";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shared-ui",
-  "version": "0.0.0",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shared-ui",
-      "version": "0.0.0",
+      "version": "0.0.15",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-select": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krystian5011/shared-ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Components library for Fluffy Labs projects",
   "author": "krystianfras95@gmail.com",
   "type": "module",


### PR DESCRIPTION
**What**
- fixed badge (dev, pr preview, beta etc)
- now built it fallback to mobile for github dropdown on `sm` breakpoint (as it happens in jam-search)
- links in GitHub menu are now modifiable via `ghRepoName` prop 
- name of the project appears now optionally even on mobile when `keepNameWhenSmall` prop set to `true`
  - set by default to `false` to avoid breaking changes 
- change styling so github button allows appears on the edge right of the header. Does not have to add `<div className="flex w-full"/>` anymore to hack this.

<img width="1006" alt="Screenshot 2025-06-18 at 20 42 58" src="https://github.com/user-attachments/assets/fd132c74-fe26-409e-9336-f983db6bde02" />
<img width="557" alt="Screenshot 2025-06-18 at 20 42 47" src="https://github.com/user-attachments/assets/73e9d060-2c3e-4a20-b131-420b5464bd71" />
