### PR TITLE
Improve dark mode switcher

### DIFF
--- a/lib/components/AppsSidebar/index.tsx
+++ b/lib/components/AppsSidebar/index.tsx
@@ -65,7 +65,7 @@ export const AppsSidebar = ({
       </div>
 
       {enableDarkModeToggle && (
-        <div className="py-4 border-t flex justify-center">
+        <div className="py-4 border-t flex justify-center border-gray-300 dark:border-gray-600">
           <ToggleDarkModeIcon />
         </div>
       )}

--- a/lib/components/DarkMode/index.tsx
+++ b/lib/components/DarkMode/index.tsx
@@ -1,19 +1,25 @@
 import { Button } from "@/ui/button";
-import { Moon, Sun } from "lucide-react";
-import { useIsDarkMode, useToggleColorMode } from "./utils";
+import { Moon, Sun, SunMoon } from "lucide-react";
+import { useThemeMode, initializeTheme } from "./theme-utils";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/ui/select";
+import { useEffect } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
+
+const ARBITRARY_ALMOST_INSTANT_DELAY_IN_MS = 250; // ms
 
 export const ToggleDarkMode = ({ className }: { className: string }) => {
-  const isDark = useIsDarkMode();
-  const toggleColorMode = useToggleColorMode();
+  const [themeMode, setThemeMode] = useThemeMode();
+
   const onClick = (val: string) => {
-    if ((isDark && val === "light") || (!isDark && val === "dark")) {
-      toggleColorMode();
-    }
+    setThemeMode(val as "light" | "dark" | "auto");
   };
 
+  useEffect(() => {
+    initializeTheme();
+  }, []);
+
   return (
-    <Select onValueChange={onClick} defaultValue={isDark ? "dark" : "light"}>
+    <Select onValueChange={onClick} defaultValue={themeMode}>
       <SelectTrigger
         onClick={(e) => {
           e.currentTarget.blur();
@@ -38,21 +44,76 @@ export const ToggleDarkMode = ({ className }: { className: string }) => {
           e.stopPropagation();
         }}
       >
-        <SelectItem value="light">Light</SelectItem>
-        <SelectItem value="dark">Dark</SelectItem>
+        <SelectItem value="light">
+          <div className="flex items-center gap-2">
+            <Sun className="h-4 w-4" />
+            <span>Light</span>
+          </div>
+        </SelectItem>
+        <SelectItem value="dark">
+          <div className="flex items-center gap-2">
+            <Moon className="h-4 w-4" />
+            <span>Dark</span>
+          </div>
+        </SelectItem>
+        <SelectItem value="auto">
+          <div className="flex items-center gap-2">
+            <SunMoon className="h-4 w-4" />
+            <span>Auto</span>
+          </div>
+        </SelectItem>
       </SelectContent>
     </Select>
   );
 };
 
 export const ToggleDarkModeIcon = () => {
-  const isDark = useIsDarkMode();
-  const toggleColorMode = useToggleColorMode();
-  const onCLick = toggleColorMode;
+  const [themeMode, setThemeMode] = useThemeMode();
+
+  const handleClick = () => {
+    // Cycle through: light -> dark -> auto -> light
+    const nextMode = themeMode === "light" ? "dark" : themeMode === "dark" ? "auto" : "light";
+
+    setThemeMode(nextMode);
+  };
+
+  const getIcon = () => {
+    switch (themeMode) {
+      case "light":
+        return <Sun width="30px" />;
+      case "dark":
+        return <Moon width="30px" />;
+      case "auto":
+        return <SunMoon width="30px" />;
+    }
+  };
+
+  const getTooltip = () => {
+    switch (themeMode) {
+      case "light":
+        return "Light Mode";
+      case "dark":
+        return "Dark Mode";
+      case "auto":
+        return "Auto Dark/Light Mode";
+    }
+  };
+
+  useEffect(() => {
+    initializeTheme();
+  }, []);
 
   return (
-    <Button onClick={onCLick} className="text-title-foreground p-2 border rounded" variant="ghost">
-      {isDark ? <Sun width="30px" /> : <Moon width="30px" />}
-    </Button>
+    <Tooltip delayDuration={ARBITRARY_ALMOST_INSTANT_DELAY_IN_MS}>
+      <TooltipTrigger asChild>
+        <Button onClick={handleClick} className="text-title-foreground p-2 border rounded" variant="ghost">
+          {getIcon()}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="right">{getTooltip()}</TooltipContent>
+    </Tooltip>
   );
 };
+
+export { initializeTheme, useThemeMode } from "./theme-utils";
+export type { ThemeMode } from "./theme-utils";

--- a/lib/components/DarkMode/theme-utils.ts
+++ b/lib/components/DarkMode/theme-utils.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark" | "auto";
+
+const THEME_MODE_KEY = "theme-mode";
+const themeChangeEvent = new Event("themeChange");
+
+let isInitialized = false;
+
+export const initializeTheme = () => {
+  if (isInitialized) return;
+  isInitialized = true;
+
+  const mode = getThemeMode();
+  applyThemeToDocument(mode);
+
+  // Listen for system theme changes when in auto mode
+  if (mode === "auto" && window.matchMedia) {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQuery.addEventListener("change", () => {
+      const currentMode = getThemeMode();
+      if (currentMode === "auto") {
+        applyThemeToDocument("auto");
+        window.dispatchEvent(themeChangeEvent);
+      }
+    });
+  }
+};
+
+export const useThemeMode = (): [ThemeMode, (mode: ThemeMode) => void] => {
+  const [mode, setMode] = useState<ThemeMode>(getThemeMode);
+
+  useEffect(() => {
+    const handleThemeChange = () => {
+      setMode(getThemeMode());
+    };
+
+    window.addEventListener("themeChange", handleThemeChange);
+    return () => window.removeEventListener("themeChange", handleThemeChange);
+  }, []);
+
+  return [mode, setThemeMode];
+};
+
+const applyThemeToDocument = (mode: ThemeMode) => {
+  const isDark = shouldUseDarkMode(mode);
+  document.documentElement.classList.toggle("dark", isDark);
+};
+
+const shouldUseDarkMode = (mode: ThemeMode): boolean => {
+  if (mode === "dark") return true;
+  if (mode === "light") return false;
+  // Auto mode: use system preference
+  return getSystemPreference();
+};
+
+const getSystemPreference = (): boolean => {
+  return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+};
+
+const getThemeMode = (): ThemeMode => {
+  const stored = localStorage.getItem(THEME_MODE_KEY);
+  if (stored === "light" || stored === "dark" || stored === "auto") {
+    return stored;
+  }
+  // Default to auto if nothing is stored
+  return "auto";
+};
+
+const setThemeMode = (mode: ThemeMode) => {
+  localStorage.setItem(THEME_MODE_KEY, mode);
+  applyThemeToDocument(mode);
+  window.dispatchEvent(themeChangeEvent);
+};

--- a/lib/components/Layout.stories.tsx
+++ b/lib/components/Layout.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { DemoLayout } from "./DemoLayout";
+import { Header } from "./Header";
+import { AppsSidebar } from "./AppsSidebar";
+import Toolname from "@/assets/tool-name.svg";
+import { useEffect } from "react";
+import { initializeTheme, useThemeMode } from "./DarkMode";
 
 const meta = {
   title: "Layout/DemoLayout",
@@ -7,11 +12,124 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
-  argTypes: {},
+  excludeStories: ["DefaultDemoLayout"],
 } satisfies Meta<typeof DemoLayout>;
 
 export default meta;
 
 type Story = StoryObj<typeof DemoLayout>;
 
-export const DefaultDemoLayout: Story = {};
+// export const DefaultDemoLayout: Story = {};
+
+export const DefaultDemoLayout: Story = {
+  render: () => {
+    return (
+      <div>
+        <Header endSlot={<div className="text-gray-100 mr-2">End slot content</div>} toolNameSrc={Toolname} />
+        <div className="flex h-full w-full items-center justify-center">
+          <AppsSidebar activeLink="debugger" />
+          <div className="w-full h-full"></div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const LayoutWithoutThemeModeSwitcher: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An example of using Header and AppsSidebar with theme mode switcher off. In such case theme mode toggle is not shown and and proper theme (auto, light or dark) needs to be initialized manually usgin `intializeTheme()` function.",
+      },
+    },
+  },
+  render: () => {
+    useEffect(() => {
+      initializeTheme();
+    }, []);
+
+    return (
+      <div>
+        <Header endSlot={<div className="text-gray-100 mr-2">End slot content</div>} toolNameSrc={Toolname} />
+        <div className="flex h-full w-full items-center justify-center">
+          <AppsSidebar activeLink="debugger" enableDarkModeToggle={false} />
+          <div className="w-full h-full"></div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const LayoutWithoutThemeModeSwitcher2: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "This is another example of using Header and AppsSidebar with theme mode switcher off. In this case, the theme mode is set to dark mode using `useThemeMode` hook. This story runs in an isolated iframe to prevent localStorage leakage.",
+      },
+      story: {
+        inline: false,
+        iframeHeight: 520,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      // Clear localStorage before rendering to isolate this story
+      useEffect(() => {
+        const storageKey = "theme-mode";
+        window.localStorage.removeItem(storageKey);
+      }, []);
+
+      return (
+        <div style={{ width: "100%", height: "100vh" }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  render: () => {
+    const [, setThemeMode] = useThemeMode();
+
+    useEffect(() => {
+      // Clear localStorage before setting theme
+      if (typeof window !== "undefined") {
+        const storageKey = "theme-mode";
+        window.localStorage.removeItem(storageKey);
+      }
+      setThemeMode("dark");
+    }, [setThemeMode]);
+
+    return (
+      <div>
+        <Header endSlot={<div className="text-gray-100 mr-2">End slot content</div>} toolNameSrc={Toolname} />
+        <div className="flex h-full w-full items-center justify-center">
+          <AppsSidebar activeLink="debugger" enableDarkModeToggle={false} />
+          <div className="w-full h-full"></div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const LayoutWithDarkModeSwitcher: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "An example of using Header and AppsSidebar with theme switcher on.",
+      },
+    },
+  },
+  render: () => {
+    return (
+      <div>
+        <Header endSlot={<div className="text-gray-100 mr-2">End slot content</div>} toolNameSrc={Toolname} />
+        <div className="flex h-full w-full items-center justify-center">
+          <AppsSidebar activeLink="debugger" />
+          <div className="w-full h-full"></div>
+        </div>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Depends on: https://github.com/FluffyLabs/shared-ui/pull/5 

## What?

### Adds auto mode in dark light theme switcher:

https://github.com/user-attachments/assets/166055fe-775a-4516-93ca-74e76d90d32c

### Fixes border color between dark/light theme swticher and the rest of icons
before:

https://github.com/user-attachments/assets/2bc574a3-a1e1-4112-aa55-b313164e086c

after:

https://github.com/user-attachments/assets/1e820d8a-2965-4e05-8705-8a9b6e7f0293


