### PR TITLE
fix: forced dark github button had ligh focus-visible in light mode

### DIFF
--- a/lib/components/Header/components/GithubDropdownMenu.tsx
+++ b/lib/components/Header/components/GithubDropdownMenu.tsx
@@ -1,7 +1,7 @@
+import { ChevronDown, EllipsisVertical, ExternalLink } from "lucide-react";
 import { useIsSmallBreakpoint } from "@/hooks";
 import { Button } from "@/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdown-menu";
-import { ChevronDown, EllipsisVertical, ExternalLink } from "lucide-react";
 
 export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
   const isSmall = useIsSmallBreakpoint();
@@ -12,7 +12,11 @@ export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
         <DropdownMenuTrigger asChild>
           <Button
             variant="outlineBrand"
-            className="max-sm:hidden text-brand bg-transparent border-brand focus:bg-[#2D2D2D] hover:bg-[#2D2D2D] hover:text-brand focus-visible:shadow-none mr-4 px-3 h-[32px]"
+            className={`
+              dark
+              max-sm:hidden text-brand bg-transparent border-brand focus:bg-[--var(--card)] hover:bg-[--var(--card)] hover:text-brand focus-visible:shadow-none mr-4 px-3 h-[32px]
+              focus-visible:ring-[var(--brand)] focus-visible:ring-offset-[var(--card)]
+              `}
           >
             Github&nbsp;
             <ChevronDown height={20} />
@@ -24,7 +28,11 @@ export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
-            className="sm:hidden text-brand bg-transparent border-brand focus:bg-[#2D2D2D] hover:bg-[#2D2D2D] hover:text-brand focus-visible:shadow-none mr-4 px-3 h-[32px] sm-hidden"
+            className={`
+              dark
+              sm:hidden text-brand bg-transparent border-brand focus:bg-[--var(--card)] hover:bg-[--var(--card)] hover:text-brand focus-visible:shadow-none mr-4 px-3 h-[32px]
+              focus-visible:ring-[var(--brand)] focus-visible:ring-offset-[var(--card)]
+              `}
           >
             <EllipsisVertical />
           </Button>

--- a/lib/ui/button-variants.tsx
+++ b/lib/ui/button-variants.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "cursor-pointer inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/476e0f05-1928-47b0-aebd-4d7886103e4a



after:

https://github.com/user-attachments/assets/2eb982cd-543b-4fe3-8f18-217ee6551f33

