### PR TITLE
feat: dark mode friendly dropdown with radio buttons

### DIFF
--- a/lib/components/Header/components/GithubDropdownMenu.tsx
+++ b/lib/components/Header/components/GithubDropdownMenu.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, EllipsisVertical, ExternalLink } from "lucide-react";
 import { useIsSmallBreakpoint } from "@/hooks";
 import { Button } from "@/ui/Button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/DropdownMenu";
 
 export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
   const isSmall = useIsSmallBreakpoint();

--- a/lib/global.css
+++ b/lib/global.css
@@ -63,8 +63,8 @@
   --secondary-foreground: hsl(0 0% 52%);
 
   --card-foreground: var(--title-foreground);
-  --popover: hsl(190 84% 4.9%);
-  --popover-foreground: hsl(210 40% 98%);
+  --popover: hsl(0 0% 14%);
+  --popover-foreground: var(--title-foreground);
   --primary: hsl(175 80% 65%);
   --primary-foreground: hsl(190 47.4% 11.2%);
   --muted: hsl(0 0% 0%);

--- a/lib/ui/Button/Button.stories.tsx
+++ b/lib/ui/Button/Button.stories.tsx
@@ -47,7 +47,6 @@ const ThemeSwitcherDecorator = (Story: React.FC) => (
   </div>
 );
 
-// All variants showcase
 export const AllVariants: Story = {
   decorators: [ThemeSwitcherDecorator],
   render: () => (
@@ -122,7 +121,6 @@ export const AllVariants: Story = {
   ),
 };
 
-// Individual variant stories
 export const Default: Story = {
   args: {
     children: "Button",
@@ -179,7 +177,6 @@ export const Link: Story = {
   decorators: [ThemeSwitcherDecorator],
 };
 
-// Size variations
 export const Small: Story = {
   args: {
     children: "Small Button",
@@ -204,7 +201,6 @@ export const Icon: Story = {
   decorators: [ThemeSwitcherDecorator],
 };
 
-// Forced color scheme variations
 export const OutlineWithForcedDark: Story = {
   args: {
     children: "Forced Dark Mode",
@@ -237,7 +233,6 @@ export const OutlineBrandWithForcedDark: Story = {
   ],
 };
 
-// Disabled state
 export const Disabled: Story = {
   args: {
     children: "Disabled",

--- a/lib/ui/DropdownMenu/DropdownMenu.stories.tsx
+++ b/lib/ui/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,420 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  ChevronDownIcon,
+  CloudIcon,
+  CreditCardIcon,
+  GithubIcon,
+  KeyboardIcon,
+  LifeBuoyIcon,
+  LogOutIcon,
+  MailIcon,
+  MessageSquareIcon,
+  PlusCircleIcon,
+  PlusIcon,
+  SettingsIcon,
+  UserIcon,
+  UserPlusIcon,
+  UsersIcon,
+} from "lucide-react";
+import * as React from "react";
+import { ToggleDarkModeIcon } from "@/components/DarkMode";
+import { Button } from "../Button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+
+const meta = {
+  title: "UI/DropdownMenu",
+  component: DropdownMenu,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof DropdownMenu>;
+
+const ThemeSwitcherDecorator = (Story: React.FC) => (
+  <div className="p-4 bg-card">
+    <div className="flex justify-between items-center mb-4 gap-2">
+      <h3 className="text-md font-semibold text-foreground">Theme Switcher</h3>
+      <ToggleDarkModeIcon />
+    </div>
+    <div className="flex flex-col gap-2 items-start">
+      <h2 className="text-lg text-foreground">Story</h2>
+      <Story />
+    </div>
+  </div>
+);
+
+const WrapWithDarkCard = (Story: React.FC) => (
+  <div className="flex flex-wrap gap-4 dark bg-[var(--card)] py-4 px-4 min-w-80">
+    <Story />
+  </div>
+);
+
+export const Basic: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open Menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuItem>
+          <UserIcon className="mr-2 h-4 w-4" />
+          <span>Profile</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <CreditCardIcon className="mr-2 h-4 w-4" />
+          <span>Billing</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <SettingsIcon className="mr-2 h-4 w-4" />
+          <span>Settings</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <LogOutIcon className="mr-2 h-4 w-4" />
+          <span>Log out</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const RadioGroup: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => {
+    const [position, setPosition] = React.useState("top");
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">
+            Position: {position}
+            <ChevronDownIcon className="ml-2 h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuLabel>Panel Position</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup value={position} onValueChange={setPosition}>
+            <DropdownMenuRadioItem value="top">Top</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="bottom">Bottom</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="right">Right</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="left">Left</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+};
+
+export const RadioGroupWithForcedDarkDome: Story = {
+  decorators: [WrapWithDarkCard, ThemeSwitcherDecorator],
+  render: () => {
+    const [position, setPosition] = React.useState("top");
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" forcedColorScheme="dark">
+            Position: {position}
+            <ChevronDownIcon className="ml-2 h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56" forcedColorScheme="dark">
+          <DropdownMenuLabel>Panel Position</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup value={position} onValueChange={setPosition}>
+            <DropdownMenuRadioItem value="top">Top</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="bottom">Bottom</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="right">Right</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="left">Left</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+};
+
+export const ColorSelection: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => {
+    const [color, setColor] = React.useState("blue");
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 rounded-full" style={{ backgroundColor: color }} />
+              <span>Color: {color}</span>
+              <ChevronDownIcon className="ml-2 h-4 w-4" />
+            </div>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuLabel>Choose a color</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup value={color} onValueChange={setColor}>
+            <DropdownMenuRadioItem value="red">
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded-full bg-red-500" />
+                Red
+              </div>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="blue">
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded-full bg-blue-500" />
+                Blue
+              </div>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="green">
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded-full bg-green-500" />
+                Green
+              </div>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="yellow">
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                Yellow
+              </div>
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="purple">
+              <div className="flex items-center gap-2">
+                <div className="w-3 h-3 rounded-full bg-purple-500" />
+                Purple
+              </div>
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+};
+
+export const CheckboxItems: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => {
+    const [showStatusBar, setShowStatusBar] = React.useState(true);
+    const [showActivityBar, setShowActivityBar] = React.useState(false);
+    const [showPanel, setShowPanel] = React.useState(false);
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">View Options</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
+            Status Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar} disabled>
+            Activity Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
+            Panel
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+};
+
+export const WithSubmenus: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open Complex Menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel>My Account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem>
+            <UserIcon className="mr-2 h-4 w-4" />
+            <span>Profile</span>
+            <DropdownMenuShortcut>⇧⌘P</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <CreditCardIcon className="mr-2 h-4 w-4" />
+            <span>Billing</span>
+            <DropdownMenuShortcut>⌘B</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <SettingsIcon className="mr-2 h-4 w-4" />
+            <span>Settings</span>
+            <DropdownMenuShortcut>⌘S</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <KeyboardIcon className="mr-2 h-4 w-4" />
+            <span>Keyboard shortcuts</span>
+            <DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem>
+            <UsersIcon className="mr-2 h-4 w-4" />
+            <span>Team</span>
+          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <UserPlusIcon className="mr-2 h-4 w-4" />
+              <span>Invite users</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem>
+                  <MailIcon className="mr-2 h-4 w-4" />
+                  <span>Email</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <MessageSquareIcon className="mr-2 h-4 w-4" />
+                  <span>Message</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                  <PlusCircleIcon className="mr-2 h-4 w-4" />
+                  <span>More...</span>
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
+          <DropdownMenuItem>
+            <PlusIcon className="mr-2 h-4 w-4" />
+            <span>New Team</span>
+            <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <GithubIcon className="mr-2 h-4 w-4" />
+          <span>GitHub</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <LifeBuoyIcon className="mr-2 h-4 w-4" />
+          <span>Support</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled>
+          <CloudIcon className="mr-2 h-4 w-4" />
+          <span>API</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <LogOutIcon className="mr-2 h-4 w-4" />
+          <span>Log out</span>
+          <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const WithDestructiveItem: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Account Actions</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel>My Account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <UserIcon className="mr-2 h-4 w-4" />
+          <span>Profile</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <SettingsIcon className="mr-2 h-4 w-4" />
+          <span>Settings</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive">
+          <LogOutIcon className="mr-2 h-4 w-4" />
+          <span>Delete Account</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const WithInsetItems: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Inset Example</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel inset>Account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem inset>Profile</DropdownMenuItem>
+        <DropdownMenuItem inset>Settings</DropdownMenuItem>
+        <DropdownMenuItem inset>Preferences</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel inset>Team</DropdownMenuLabel>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger inset>Invite users</DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Email</DropdownMenuItem>
+              <DropdownMenuItem>Message</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem>More...</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const ControlledOpenState: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+      <div className="flex items-center gap-4">
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">{open ? "Menu is Open" : "Menu is Closed"}</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-56">
+            <DropdownMenuLabel>Controlled Menu</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => console.log("Profile clicked")}>Profile</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => console.log("Settings clicked")}>Settings</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => setOpen(false)}>Close Menu</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button variant="secondary" onClick={() => setOpen(!open)}>
+          Toggle Menu Externally
+        </Button>
+      </div>
+    );
+  },
+};

--- a/lib/ui/DropdownMenu/dropdown-menu.tsx
+++ b/lib/ui/DropdownMenu/dropdown-menu.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-
+import * as React from "react";
+import { useMemo } from "react";
 import { cn } from "@/utils";
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -16,23 +16,49 @@ function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownM
   return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
+type DropdownMenuContextValue = {
+  forcedColorScheme?: "light" | "dark";
+};
+
+const context = React.createContext<DropdownMenuContextValue | undefined>(undefined);
+
+const useDropdownMenuContext = () => {
+  const contextValue = React.useContext(context);
+  if (!contextValue) {
+    throw new Error("useDropdownMenuContext must be used within a DropdownMenuContext");
+  }
+  return contextValue;
+};
+
 function DropdownMenuContent({
   className,
   sideOffset = 4,
+  forcedColorScheme,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & { forcedColorScheme?: "light" | "dark" }) {
+  const contextValue = useMemo(
+    () => ({
+      forcedColorScheme,
+    }),
+    [forcedColorScheme],
+  );
+
   return (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        data-slot="dropdown-menu-content"
-        sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
-          className,
-        )}
-        {...props}
-      />
-    </DropdownMenuPrimitive.Portal>
+    <context.Provider value={contextValue}>
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content
+          data-slot="dropdown-menu-content"
+          sideOffset={sideOffset}
+          className={cn(
+            "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+            "border-[var(--border)]",
+            className,
+            forcedColorScheme === "dark" && `dark border-[var(--border)] bg-[var(--card)]`,
+          )}
+          {...props}
+        />
+      </DropdownMenuPrimitive.Portal>
+    </context.Provider>
   );
 }
 
@@ -98,11 +124,15 @@ function DropdownMenuRadioItem({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  const { forcedColorScheme } = useDropdownMenuContext();
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 my-0.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=checked]:bg-[var(--brand)] data-[state=checked]:text-[var(--card)] data-[state=checked]:hover:opacity-100 data-[state=checked]:focus:opacity-100",
+        "data-[highlighted]:bg-[var(--title-foreground)] data-highlighted:text-[var(--card)]",
+        forcedColorScheme === "dark" && `transition-none text-[var(--title-foreground)] rounded-sm`,
         className,
       )}
       {...props}
@@ -124,21 +154,29 @@ function DropdownMenuLabel({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
   inset?: boolean;
 }) {
+  const { forcedColorScheme } = useDropdownMenuContext();
+
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        forcedColorScheme === "dark" && "text-[var(--title-foreground)]",
+        className,
+      )}
       {...props}
     />
   );
 }
 
 function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  const { forcedColorScheme } = useDropdownMenuContext();
+
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn("bg-border -mx-1 my-1 h-px", forcedColorScheme === "dark" && "bg-[var(--border)]", className)}
       {...props}
     />
   );

--- a/lib/ui/DropdownMenu/index.ts
+++ b/lib/ui/DropdownMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./dropdown-menu";

--- a/lib/ui/index.ts
+++ b/lib/ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./DropdownMenu";


### PR DESCRIPTION
**What**
- Dropdown popover, label, separator and radio items are adjusted to be dark mode friendly -> together with `forcedColorScheme` approach.
- added examples in Storybook stories to modified components, and for the remaining one. The remaining one may not look very good; but was their original state.
- colors are picked according to my taste as I haven't found any design for it; basically it matches the looks of dark mode outline button and some proper ux patterns 

**What is not done**
Remaining components of Dropdown are not adjusted for the dark mode, because they are not used anywhere so far.

<img width="329" height="258" alt="Screenshot 2025-08-19 at 21 14 39" src="https://github.com/user-attachments/assets/6ba98a90-7ebd-47ff-b124-fdaf5f8cc870" />
