### PR TITLE
fix: chevrondown for github button didn't match the text size

### DIFF
--- a/lib/components/Header/components/GithubDropdownMenu.tsx
+++ b/lib/components/Header/components/GithubDropdownMenu.tsx
@@ -12,7 +12,7 @@ export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
         <DropdownMenuTrigger asChild>
           <Button variant="outlineBrand" forcedColorScheme="dark" className={"mr-4 px-3 h-[32px]"}>
             Github&nbsp;
-            <ChevronDown height={20} />
+            <ChevronDown className="ml-2 h-5 w-4" />
           </Button>
         </DropdownMenuTrigger>
       )}


### PR DESCRIPTION
before:
<img width="423" height="82" alt="Screenshot 2025-08-19 at 21 19 45" src="https://github.com/user-attachments/assets/483d66ff-e078-4445-aad5-befc60166907" />

after:
<img width="257" height="70" alt="Screenshot 2025-08-19 at 21 20 47" src="https://github.com/user-attachments/assets/bb67d98a-dd68-4669-89aa-6a599156b0f0" />
