### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluffylabs/shared-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluffylabs/shared-ui",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-select": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluffylabs/shared-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Components library for Fluffy Labs projects",
   "author": "krystianfras95@gmail.com",
   "type": "module",


### PR DESCRIPTION
## 🚀 Release v0.1.1

### Version Bump
**0.1.0 ➡️ 0.1.1**

### Commits included in this release

- feat: dark mode friendly dropdown with radio buttons (#18) 9778c1b51cd0ec4e6223f1d8a52c923b72d3c854
- fix: chevrondown for github button didn't match the text size (#19) 4a847655bc21c3d5e5cbfc94b74c1375efe1072a
- feat: make forced dark buttons more generic (#17) 0df4268f8133a8f12a01c9c21fa772872c4a517c
- fix: forced dark github button had ligh focus-visible in light mode (#15) e59580f0fbe487e2ebb311eace5754277d97b9d3
- feat: allow redirecting to beta (#14) 441e52bf91eaf0132578b02be47874345d278afe
- fix(releaseWorkflow): udpate release workflow (#13) d27a46b1de50efb1dd66cf1707f25f7d82cf88b2
### Additional Information
- Triggered by: chmurson
- Source branch: main

---

**Note:** After merging this PR, run 'Release step 2' workflow to create a GitHub release.