### PR TITLE
style: adjust dropdown with chebkoxes and radio button styles

### DIFF
--- a/lib/global.css
+++ b/lib/global.css
@@ -26,7 +26,7 @@
   /*  */
   --muted: hsl(220 20% 97%);
   --muted-foreground: hsl(0 0% 72%);
-  --accent: var(--background);
+  --accent: hsl(0 0% 97%);
   --accent-foreground: var(--foreground);
   /* Defaults */
   --destructive: hsl(0 84.2% 60.2%);

--- a/lib/ui/Button/button-variants.tsx
+++ b/lib/ui/Button/button-variants.tsx
@@ -8,7 +8,7 @@ export const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground dark:text-title-foreground dark:bg-transparent dark:hover:bg-[var(--title)]",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground text-title-foreground dark:text-title-foreground dark:bg-transparent dark:hover:bg-[var(--title)]",
         outlineBrand:
           "border border-input border-brand-dark dark:border-brand dark:text-brand hover:bg-brand-dark hover:text-brand",
         secondary:

--- a/lib/ui/DropdownMenu/DropdownMenu.stories.tsx
+++ b/lib/ui/DropdownMenu/DropdownMenu.stories.tsx
@@ -126,7 +126,7 @@ export const RadioGroup: Story = {
   },
 };
 
-export const RadioGroupWithForcedDarkDome: Story = {
+export const RadioGroupWithForcedDarkTheme: Story = {
   decorators: [WrapWithDarkCard, ThemeSwitcherDecorator],
   render: () => {
     const [position, setPosition] = React.useState("top");
@@ -148,6 +148,68 @@ export const RadioGroupWithForcedDarkDome: Story = {
             <DropdownMenuRadioItem value="right">Right</DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="left">Left</DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+};
+
+export const CheckboxItems: Story = {
+  decorators: [ThemeSwitcherDecorator],
+  render: () => {
+    const [showStatusBar, setShowStatusBar] = React.useState(true);
+    const [showActivityBar, setShowActivityBar] = React.useState(false);
+    const [showPanel, setShowPanel] = React.useState(false);
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">View Options</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
+            Status Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar} disabled>
+            Activity Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
+            Panel
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+};
+
+export const CheckboxItemsWithForcedDarkTheme: Story = {
+  decorators: [WrapWithDarkCard, ThemeSwitcherDecorator],
+  render: () => {
+    const [showStatusBar, setShowStatusBar] = React.useState(true);
+    const [showActivityBar, setShowActivityBar] = React.useState(false);
+    const [showPanel, setShowPanel] = React.useState(false);
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" forcedColorScheme="dark">
+            View Options
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56" forcedColorScheme="dark">
+          <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
+            Status Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar} disabled>
+            Activity Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
+            Panel
+          </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>
     );
@@ -205,36 +267,6 @@ export const ColorSelection: Story = {
               </div>
             </DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-  },
-};
-
-export const CheckboxItems: Story = {
-  decorators: [ThemeSwitcherDecorator],
-  render: () => {
-    const [showStatusBar, setShowStatusBar] = React.useState(true);
-    const [showActivityBar, setShowActivityBar] = React.useState(false);
-    const [showPanel, setShowPanel] = React.useState(false);
-
-    return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline">View Options</Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56">
-          <DropdownMenuLabel>Appearance</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
-            Status Bar
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar} disabled>
-            Activity Bar
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
-            Panel
-          </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>
     );

--- a/lib/ui/DropdownMenu/dropdown-menu.tsx
+++ b/lib/ui/DropdownMenu/dropdown-menu.tsx
@@ -95,11 +95,18 @@ function DropdownMenuCheckboxItem({
   checked,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  const { forcedColorScheme } = useDropdownMenuContext();
+
   return (
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm",
+        "outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[highlighted]:bg-[var(--accent)] data-highlighted:text-[var(--accent-foreground)]",
+        "data-[state=checked]:text-[var(--brand-dark)] focus:data-[state=checked]:text-[var(--brand-dark)]",
+        "dark:data-[state=checked]:text-[var(--brand-light)] dark:focus:data-[state=checked]:text-[var(--brand-light)]",
+        forcedColorScheme === "dark" && "hover:dark:bg-[var(--accent)] hover:dark:text-[var(--accent-foreground)] ",
         className,
       )}
       checked={checked}
@@ -124,22 +131,23 @@ function DropdownMenuRadioItem({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
-  const { forcedColorScheme } = useDropdownMenuContext();
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
+        "group",
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 my-0.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "data-[state=checked]:bg-[var(--brand)] data-[state=checked]:text-[var(--card)] data-[state=checked]:hover:opacity-100 data-[state=checked]:focus:opacity-100",
-        "data-[highlighted]:bg-[var(--title-foreground)] data-highlighted:text-[var(--card)]",
-        forcedColorScheme === "dark" && `transition-none text-[var(--title-foreground)] rounded-sm`,
+        "data-[state=checked]:text-[var(--brand-dark)] focus:data-[state=checked]:text-[var(--brand-dark)]",
+        "dark:data-[highlighted]:bg-[var(--accent)] dark:data-highlighted:text-[var(--accent-foreground)]",
+        "dark:data-[state=checked]:text-[var(--brand-light)] dark:data-highlighted:data-[state=checked]:text-[var(--brand-light)]",
+        "data-[highlighted]:bg-[var(--accent)] data-highlighted:text-[var(--accent-foreground)]",
         className,
       )}
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <CircleIcon className="size-2 fill-current dark:text-[var(--brand-light)] text-[var(--brand-dark)]" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}


### PR DESCRIPTION
**What?**

I've adjusted styles for dropdown checkboxes and radio buttons 
- consistent colors between checkboxes and radio buttons
- looks good in light and dark mode (e.g. fixed accent color)
- radio button does not have bg color changed for active/checked item; but text color instead 


https://github.com/user-attachments/assets/8f2685f0-3ca5-4213-9f8b-db7f2b5f8705

https://github.com/user-attachments/assets/d67a5d76-664d-4dc7-9ba1-ab044ecc948a

before:
<img width="352" height="384" alt="Screenshot 2025-08-21 at 10 52 50" src="https://github.com/user-attachments/assets/bf21ea0b-920e-4cd2-bb39-197d97af4469" />

after:
<img width="323" height="361" alt="Screenshot 2025-08-21 at 10 52 36" src="https://github.com/user-attachments/assets/bb97d454-83cb-4d7b-915f-10f7e2e7b5c5" />

