### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluffylabs/shared-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluffylabs/shared-ui",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-select": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluffylabs/shared-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Components library for Fluffy Labs projects",
   "author": "krystianfras95@gmail.com",
   "type": "module",


### PR DESCRIPTION
## 🚀 Release v0.1.2

### Version Bump
**0.1.1 ➡️ 0.1.2**

### Commits included in this release

- style: adjust dropdown with chebkoxes and radio button styles (#23) 577801dfc9cf50e749799bd32ed492fece64ec8d
- Add state viewer instead of trie (#22) 294b3088117cf3dff3d7741197ff90b15768d738
### Additional Information
- Triggered by: chmurson
- Source branch: main

---

**Note:** After merging this PR, run 'Release step 2' workflow to create a GitHub release.