### PR TITLE
chore(ci): bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/shared-ui-bump-version-and-create-pr.yml
+++ b/.github/workflows/shared-ui-bump-version-and-create-pr.yml
@@ -173,7 +173,7 @@ jobs:
           base: main
 
       - name: 📦 Create draft GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.bump.outputs.new_version }}
           name: v${{ steps.bump.outputs.new_version }}

--- a/.github/workflows/storybook-cd.yml
+++ b/.github/workflows/storybook-cd.yml
@@ -39,11 +39,11 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./storybook-static"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Bumps four GitHub Actions to their latest major versions:

- `actions/configure-pages` v5 → v6
- `actions/upload-pages-artifact` v4 → v5
- `actions/deploy-pages` v4 → v5
- `softprops/action-gh-release` v2 → v3

All four are Node 20 → Node 24 runtime upgrades with no consumer API changes; `ubuntu-latest` already supports Node 24. The other actions in this repo (`checkout@v6`, `setup-node@v6`, `create-pull-request@v8`) were already on the latest major tag.

## Test plan
- [ ] Storybook CD workflow succeeds on next push to `main`
- [ ] Release bump workflow succeeds on next version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)